### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## 需要安装的依赖列表：
 
- - Python 3.7+
+ - Python 3.6+
  - PySide6
  - qasync
  - websockets


### PR DESCRIPTION
更改“需要安装的依赖列表”中的 Python 版本号为 Python 3.6+，原 Python 3.7+ 因为只需要 Python 3.6+ 就可以用